### PR TITLE
Add support for SVG images

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Currently, Xairo supports
   * Bézier curves
   * rectangles
 * creating solid, gradient, and mesh color sources
-* saving images as *.png files
+* adding simple text to an image
+* manipulating image paths and text with transformation matrices
+* saving images in *.png or *.svg format
 
 For full documentation, see the [`Xairo` module](lib/xairo.ex).
 

--- a/lib/xairo/image.ex
+++ b/lib/xairo/image.ex
@@ -15,14 +15,14 @@ defmodule Xairo.Image do
 
   As an example, the following code
 
-      iex> image = Image.new(100, 100, 1)
-      iex> image |> Xairo.move_to(10, 10) |> Xairo.line_to(90, 90)
+      iex> image = Image.new(100, 100)
+      iex> image |> Xairo.move_to({10, 10}) |> Xairo.line_to({90, 90})
 
   will produce a 100x100 pixel image with a line from (10, 10) to (90, 90),
   and this code
 
       iex> image = Image.new(100, 100, 3)
-      iex> image |> Xairo.move_to(10, 10) |> Xairo.line_to(90, 90)
+      iex> image |> Xairo.move_to({10, 10}) |> Xairo.line_to({90, 90})
 
   will produce a 300x300 pixel image with a line from (30, 30) to (270, 270).
 

--- a/lib/xairo/native.ex
+++ b/lib/xairo/native.ex
@@ -6,6 +6,9 @@ defmodule Xairo.Native do
   def new_image(_w, _h), do: error()
   def save_image(_i, _f), do: error()
 
+  def new_svg_image(_f, _w, _h), do: error()
+  def set_document_unit(_i, _u), do: error()
+
   def move_to(_i, _p), do: error()
   def line_to(_i, _p), do: error()
   def stroke(_i), do: error()

--- a/lib/xairo/native_fn.ex
+++ b/lib/xairo/native_fn.ex
@@ -15,12 +15,12 @@ defmodule Xairo.NativeFn do
       end)
 
     quote do
-      def unquote(func_name)(%Xairo.Image{} = image, unquote_splicing(signature_args)) do
+      def unquote(func_name)(%{resource: resource} = image, unquote_splicing(signature_args)) do
         result =
           apply(
             Xairo.Native,
             unquote(func_name),
-            [image.resource, unquote_splicing(applied_args)]
+            [resource, unquote_splicing(applied_args)]
           )
 
         case result do

--- a/lib/xairo/svg_image.ex
+++ b/lib/xairo/svg_image.ex
@@ -1,0 +1,158 @@
+defmodule Xairo.SvgImage do
+  @moduledoc """
+  `Xairo.SvgImage` provides a wrapper around the in-memory C representation of a
+  cairo image that will be rendered to an SVG document.
+
+  In addition to a reference to the C resource, it stores information about the
+  `filename`, `width`, `height`, `scale` and `unit` of the cairo image.  The
+  width and height are stored as unscaled so that they can be used in
+  calculations of userspace while drawing, while ensuring that they are
+  correctly scaled on the generated image.
+
+  There are two ways to scale an `SvgImage` up or down. By changing the scale value, or by changing the document unit, though depending on when they are called,
+  they differ in their final effect.
+
+  Setting the scale when initializing the image will correctly scale the image's
+  final dimensions to match the scale. Calling `Xairo.scale/3` in the middle of
+  creating an image will change the scale for any subsequent paths drawn, but will not change the final image size
+
+  Calling `Xairo.set_document_unit/2` at any point during an image's lifecycle
+  will update the final unit at which the image is rendered. This can be called
+  as many times as you like, but only the last set unit will be used, and it
+  will apply to all paths and text rendered as part of the image, regardless
+  of when it was called.
+
+  This means that scaling an image up is as easy as either increasing the
+  scale value when creating the image, or simply changing the final rendered
+  unit to a larger unit.
+
+  As an example, the following code
+
+      iex> image = SvgImage.new("test.svg", 100, 100)
+      iex> image |> Xairo.move_to({10, 10}) |> Xairo.line_to({90, 90})
+
+  will produce a 100x100 point image with a line from (10, 10) to (90, 90),
+  and this code
+
+      iex> image = SvgImage.new("test.svg", 100, 100, scale: 3, unit: :mm)
+      iex> image |> Xairo.move_to({10, 10}) |> Xairo.line_to({90, 90})
+
+  will produce a 300x300 millimeter image with a line from (30, 30) to (270, 270).
+
+  ### Document units
+
+  The document unit for an `SvgImage` can be set in a call to `Xairo.new_svg_image/4`, or by calling `Xairo.set_document_unit/2` at any point during the image lifecycle. This is the unit that will determine the final width and height of the image, and the unit of the coordinate grid for positioning and rendering paths
+
+  Unit types are represented by atoms, and can be any of the following:
+
+  - `:px` - one pixel
+  - `:pt` - one point: this is the default unit if none is specified, and is equal to 1.333 pixels
+  - `:in` - one inch (96 pixels)
+  - `:cm` - one centimeter (~ 37.8 pixels)
+  - `:mm` - one millimeter (~ 3.78 pixels)
+  - `:pc` - one pica (1/6 inch, 16 pixels)
+  - `:em` - the size of the element's font (ends up ~ 12 pixels)
+  - `:ex` - the x-height of the element's font (ends up ~ 1/2 of the :em value, or ~ 6 pixels)
+  - `:user` - pulled from lower level OS settings. Usually equivalent to a pixel.
+  - `:percent` - some percent of another reference value (in my tests, this ends up being 200%)
+  """
+
+  defstruct [
+    :resource,
+    :width,
+    :height,
+    :scale,
+    :unit,
+    :reference,
+    :filename
+  ]
+
+  @type svg_unit ::
+          :user
+          | :em
+          | :ex
+          | :px
+          | :in
+          | :cm
+          | :mm
+          | :pt
+          | :pc
+          | :percent
+
+  @type t :: %__MODULE__{
+          resource: reference(),
+          width: number(),
+          height: number(),
+          scale: number(),
+          unit: svg_unit(),
+          reference: reference(),
+          filename: String.t()
+        }
+
+  @doc """
+  Creates a new `SvgImage`
+
+  Takes as required arguments a filename, width, and height. Optional keyword arguments can be giving for `scale` and `unit`.
+
+  The default value for scale is 1.0, and the default value for `unit` is a `point` (about 1 1/3 pixels)
+
+  ## Example
+
+      iex> SvgImage.new("test.svg", 100, 100, scale: 2)
+
+  creates a new image "test.svg" that is 200x200 points in size.
+
+      iex> SvgImage.new("test.svg", 100, 100, unit: :in)
+
+  creates an image "test.svg" that is 100x100 inches in size.
+  """
+  @spec new(String.t(), number(), number(), Keyword.t() | nil) :: __MODULE__.t()
+  def new(filename, width, height, opts \\ []) do
+    scale = Keyword.get(opts, :scale, 1.0)
+    unit = Keyword.get(opts, :unit, :pt)
+
+    width = width * 1.0
+    height = height * 1.0
+    scale = scale * 1.0
+    scaled_width = scale * width
+    scaled_height = scale * height
+    {:ok, resource} = Xairo.Native.new_svg_image(scaled_width, scaled_height, filename)
+    Xairo.Native.scale(resource, scale, scale)
+    Xairo.Native.set_document_unit(resource, unit)
+
+    %__MODULE__{
+      filename: filename,
+      unit: unit,
+      width: width,
+      height: height,
+      scale: scale,
+      resource: resource,
+      reference: make_ref()
+    }
+  end
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    def inspect(
+          %Xairo.SvgImage{
+            width: width,
+            height: height,
+            scale: scale,
+            reference: reference,
+            unit: unit,
+            filename: filename
+          },
+          opts
+        ) do
+      concat([
+        "#SvgImage<",
+        "#{width}x#{height}@#{scale} ",
+        "(#{unit})",
+        filename,
+        to_doc(reference, opts),
+        ">"
+      ])
+    end
+  end
+end

--- a/native/xairo/Cargo.toml
+++ b/native/xairo/Cargo.toml
@@ -13,5 +13,5 @@ crate-type = ["cdylib"]
 rustler = "0.22.2"
 rustler_codegen = "0.22.2"
 png = "0.11.0"
-cairo-rs = { version = "0.14.0", features = ["png"] }
+cairo-rs = { version = "0.14.0", features = ["png", "svg", "v1_16"] }
 thiserror = "1.0"

--- a/native/xairo/src/error.rs
+++ b/native/xairo/src/error.rs
@@ -21,6 +21,8 @@ pub enum Error {
     TranslatedVector,
     #[error("Error fetching translated point")]
     TranslatedPoint,
+    #[error("Mismatched file type")]
+    FileTypeMismatch,
 }
 
 impl rustler::Encoder for Error {

--- a/native/xairo/src/lib.rs
+++ b/native/xairo/src/lib.rs
@@ -21,7 +21,9 @@ rustler::init!(
     "Elixir.Xairo.Native",
     [
         xairo_image::new_image,
+        xairo_image::new_svg_image,
         xairo_image::save_image,
+        xairo_image::set_document_unit,
 
         drawing::move_to,
         drawing::rel_move_to,

--- a/native/xairo/src/xairo_image.rs
+++ b/native/xairo/src/xairo_image.rs
@@ -1,12 +1,32 @@
-use cairo::{Context, Format, ImageSurface};
+use cairo::{Context, Format, ImageSurface, SvgSurface};
 use rustler::ResourceArc;
 use std::fs::File;
 use crate::error::Error;
 
+#[derive(Copy,Clone,Debug,NifUnitEnum)]
+pub enum SvgUnit {
+    Em,
+    Ex,
+    Px,
+    In,
+    Cm,
+    Mm,
+    Pt,
+    Pc,
+    Percent,
+    User,
+}
+
+#[derive(Debug)]
+pub enum XairoSurface {
+    Image(ImageSurface),
+    Svg(SvgSurface)
+}
+
 #[derive(Debug)]
 pub struct XairoImage {
     pub context: Context,
-    pub surface: ImageSurface
+    pub surface: XairoSurface
 }
 
 impl XairoImage {
@@ -14,9 +34,32 @@ impl XairoImage {
         match ImageSurface::create(Format::ARgb32, width, height) {
             Ok(surface) => {
                 match Context::new(&surface) {
-                    Ok(context) => Ok(Self { context, surface }),
+                    Ok(context) => Ok(
+                        Self {
+                            context,
+                            surface: XairoSurface::Image(surface)
+                        }
+                    ),
                     Err(_) => Err(Error::ContextCreate)
                 }
+            },
+            Err(_) => Err(Error::SurfaceCreate)
+        }
+    }
+
+    pub fn new_svg(width: f64, height: f64, filename: String) -> Result<Self, Error> {
+        match SvgSurface::new(width, height, Some(filename)) {
+            Ok(surface) => {
+                match Context::new(&surface) {
+                    Ok(context) => Ok(
+                        Self {
+                            context,
+                            surface: XairoSurface::Svg(surface)
+                        }
+                    ),
+                    Err(_) => Err(Error::ContextCreate)
+                }
+
             },
             Err(_) => Err(Error::SurfaceCreate)
         }
@@ -25,11 +68,29 @@ impl XairoImage {
     pub fn save(&self, filename: String) -> Result<(), Error> {
         match File::create(&filename) {
             Ok(mut file) =>
-                match self.surface.write_to_png(&mut file) {
-                    Ok(_) => Ok(()),
-                    Err(_) => Err(Error::FileWrite(filename))
+                match &self.surface {
+                    XairoSurface::Image(surface) => {
+                        match surface.write_to_png(&mut file) {
+                            Ok(_) => Ok(()),
+                            Err(_) => Err(Error::FileWrite(filename))
+                        }
+                    },
+                    XairoSurface::Svg(surface) => {
+                        surface.finish();
+                        Ok(())
+                    }
                 },
             Err(_) => Err(Error::FileCreate(filename))
+        }
+    }
+
+    fn set_document_unit(&self, unit: SvgUnit) -> Result<(), Error> {
+        match &self.surface {
+            XairoSurface::Svg(surface) => {
+                surface.clone().set_document_unit(match_svg_unit(unit));
+                Ok(())
+            },
+            XairoSurface::Image(_) => Err(Error::FileTypeMismatch)
         }
     }
 }
@@ -49,6 +110,14 @@ pub fn new_image(width: i32, height: i32) -> ImageResult {
 }
 
 #[rustler::nif]
+pub fn new_svg_image(width: f64, height: f64, filename: String) -> ImageResult {
+    match XairoImage::new_svg(width, height, filename) {
+        Ok(image) => Ok(ResourceArc::new(image)),
+        Err(e) => Err(e)
+    }
+}
+
+#[rustler::nif]
 pub fn save_image(image: ImageArc, filename: String) -> ImageResult {
     match image.save(filename) {
         Ok(_) => Ok(image),
@@ -56,4 +125,26 @@ pub fn save_image(image: ImageArc, filename: String) -> ImageResult {
     }
 }
 
+#[rustler::nif]
+pub fn set_document_unit(image: ImageArc, unit: SvgUnit) -> ImageResult {
+    match image.set_document_unit(unit) {
+        Ok(_) => Ok(image),
+        Err(e) => Err(e)
+    }
+}
 
+fn match_svg_unit(unit: SvgUnit) -> cairo::SvgUnit {
+    match unit {
+        SvgUnit::Em => cairo::SvgUnit::Em,
+        SvgUnit::Ex => cairo::SvgUnit::Ex,
+        SvgUnit::Px => cairo::SvgUnit::Px,
+        SvgUnit::In => cairo::SvgUnit::In,
+        SvgUnit::Cm => cairo::SvgUnit::Cm,
+        SvgUnit::Mm => cairo::SvgUnit::Mm,
+        SvgUnit::Pt => cairo::SvgUnit::Pt,
+        SvgUnit::Pc => cairo::SvgUnit::Pc,
+        SvgUnit::Percent => cairo::SvgUnit::Percent,
+        SvgUnit::User => cairo::SvgUnit::User
+
+    }
+}

--- a/test/helpers/image_helpers.ex
+++ b/test/helpers/image_helpers.ex
@@ -3,7 +3,7 @@ defmodule Xairo.Helpers.ImageHelpers do
 
   import ExUnit.Assertions
 
-  def assert_image(image, path) do
+  def assert_image(%Xairo.Image{} = image, path) do
     Xairo.save_image(image, path)
 
     actual = hash(path)
@@ -14,11 +14,27 @@ defmodule Xairo.Helpers.ImageHelpers do
     :ok = File.rm(path)
   end
 
+  def assert_image(%Xairo.SvgImage{} = image, path) do
+    Xairo.save_image(image, path)
+
+    actual = read(path)
+    expected = read("test/images/" <> path)
+
+    assert actual == expected
+
+    :ok == File.rm(path)
+  end
+
   defp hash(file) do
     File.stream!(file)
     |> Enum.reduce(:crypto.hash_init(:sha256), fn line, acc ->
       :crypto.hash_update(acc, line)
     end)
     |> :crypto.hash_final()
+  end
+
+  defp read(file) do
+    {content, 0} = System.cmd("cat", [file])
+    String.replace(content, ~r/id=\".*\"/, "id=\"\"")
   end
 end

--- a/test/images/basic.svg
+++ b/test/images/basic.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100pc" height="100pc" viewBox="0 0 100 100" version="1.1">
+<g id="surface1">
+<rect x="0" y="0" width="100" height="100" style="fill:rgb(50%,0%,100%);fill-opacity:1;stroke:none;"/>
+<path style="fill:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke:rgb(100%,100%,100%);stroke-opacity:1;stroke-miterlimit:10;" d="M 10 10 L 90 90 "/>
+</g>
+</svg>

--- a/test/xairo/svg_image_test.exs
+++ b/test/xairo/svg_image_test.exs
@@ -1,0 +1,25 @@
+# test/xairo/svg_image_test.exs
+defmodule Xairo.SvgImageTest do
+  import Xairo.Helpers.ImageHelpers
+  use ExUnit.Case, async: true
+
+  alias Xairo.SvgImage
+  doctest SvgImage
+
+  setup do
+    on_exit(fn ->
+      File.rm("test.svg")
+    end)
+  end
+
+  test "creating a basic image" do
+    Xairo.new_svg_image("basic.svg", 100, 100, unit: :pc)
+    |> Xairo.set_color(0.5, 0, 1)
+    |> Xairo.paint()
+    |> Xairo.set_color(1, 1, 1)
+    |> Xairo.move_to({10, 10})
+    |> Xairo.line_to({90, 90})
+    |> Xairo.stroke()
+    |> assert_image("basic.svg")
+  end
+end


### PR DESCRIPTION
In Elixir

* Add Xairo.SvgImage struct
* Add functions to create new svg image and set document unit
* Improve typespecs to allow for either image type

In Rust

*  XairoSurface as a wrapper enum for
    * ImageSurface
    * SvgSurface
* XairoImage still manages both (we'll see if this is sustainable, but
  makes some things much easier)
* NIFs for the Elixir functions
