### PR TITLE
Fix GH workflow for caching PLTs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         id: rust-cache
         with:
           working-directory: ./native/xairo
-          key: ${{ matrix.otp }}-${{ matrix.elixir }}
+          key: rs-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('Cargo.lock') }}
 
       - name: mix-cache
         uses: actions/cache@v2
@@ -79,7 +79,7 @@ jobs:
           path: |
             _build/test/*.plt
             _build/test/*.plt.dash
-          key: ${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('mix.lock') }}-plt
+          key: plt-${{ runner.os }}-${{ matrix.otp }}-${{ matrix.elixir }}-${{ hashFiles('mix.lock') }}
 
       - name: cargo build
         run: cargo build

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,8 @@ defmodule Xairo.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       elixirc_paths: compiler_paths(Mix.env()),
-      dialyzer: [plt_add_apps: [:ex_unit]]
+      dialyzer: [plt_add_apps: [:ex_unit]],
+      plt_core_path: "_build/#{Mix.env()}"
     ]
   end
 


### PR DESCRIPTION
Dialyzer was inconsistently not seeming to cache correctly. The solution seems to be to set `plt_core_path` in mix.exs based on

https://elixirforum.com/t/caching-dialyzer-output-with-github-actions/27648/2

also, re-key the caches to be consistent
