### PR TITLE
Add transformation operations on `Xairo.Matrix`

### DIFF
--- a/lib/xairo/matrix.ex
+++ b/lib/xairo/matrix.ex
@@ -60,6 +60,40 @@ defmodule Xairo.Matrix do
     struct(__MODULE__, opts)
   end
 
+  def identity, do: new()
+
+  def translate(%__MODULE__{} = matrix, xt, yt) do
+    Xairo.Native.matrix_translate(matrix, xt * 1.0, yt * 1.0)
+  end
+
+  def scale(%__MODULE__{} = matrix, xx, yy) do
+    Xairo.Native.matrix_scale(matrix, xx * 1.0, yy * 1.0)
+  end
+
+  def rotate(%__MODULE__{} = matrix, radians) do
+    Xairo.Native.matrix_rotate(matrix, radians * 1.0)
+  end
+
+  def invert(%__MODULE__{} = matrix) do
+    with {:ok, matrix} <- Xairo.Native.matrix_invert(matrix) do
+      matrix
+    end
+  end
+
+  def multiply(%__MODULE__{} = matrix1, %__MODULE__{} = matrix2) do
+    Xairo.Native.matrix_multiply(matrix1, matrix2)
+  end
+
+  alias Xairo.{Point, Vector}
+
+  def transform_point(%__MODULE__{} = matrix, %Point{} = point) do
+    Xairo.Native.matrix_transform_point(matrix, point)
+  end
+
+  def transform_distance(%__MODULE__{} = matrix, %Vector{} = vector) do
+    Xairo.Native.matrix_transform_distance(matrix, vector)
+  end
+
   defimpl Inspect do
     import Inspect.Algebra
 

--- a/lib/xairo/native.ex
+++ b/lib/xairo/native.ex
@@ -58,5 +58,14 @@ defmodule Xairo.Native do
   def device_to_user(_i, _p), do: error()
   def device_to_user_distance(_i, _v), do: error()
 
+  def matrix_translate(_m, _xt, _yt), do: error()
+  def matrix_scale(_m, _xx, _yy), do: error()
+  def matrix_rotate(_m, _r), do: error()
+  def matrix_invert(_m), do: error()
+  def matrix_multiply(_m1, _m2), do: error()
+
+  def matrix_transform_point(_m, _p), do: error()
+  def matrix_transform_distance(_m, _v), do: error()
+
   defp error, do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/native/xairo/src/error.rs
+++ b/native/xairo/src/error.rs
@@ -23,6 +23,8 @@ pub enum Error {
     TranslatedPoint,
     #[error("Mismatched file type")]
     FileTypeMismatch,
+    #[error("Uninvertible matrix")]
+    UninvertibleMatrix,
 }
 
 impl rustler::Encoder for Error {

--- a/native/xairo/src/lib.rs
+++ b/native/xairo/src/lib.rs
@@ -64,6 +64,14 @@ rustler::init!(
         matrix::device_to_user,
         matrix::device_to_user_distance,
 
+        matrix::matrix_translate,
+        matrix::matrix_scale,
+        matrix::matrix_rotate,
+        matrix::matrix_invert,
+        matrix::matrix_multiply,
+        matrix::matrix_transform_point,
+        matrix::matrix_transform_distance,
+
         transformations::translate,
         transformations::rotate,
         transformations::transform,

--- a/native/xairo/src/transformations.rs
+++ b/native/xairo/src/transformations.rs
@@ -16,7 +16,7 @@ fn rotate(image: ImageArc, rad: f64) -> ImageArc {
 
 #[rustler::nif]
 fn transform(image: ImageArc, matrix: Matrix) -> ImageArc {
-    let matrix = matrix.to_cairo_matrix();
+    let matrix = cairo::Matrix::from(matrix);
     image.context.transform(matrix);
     image
 }

--- a/test/xairo/matrix_test.exs
+++ b/test/xairo/matrix_test.exs
@@ -5,6 +5,8 @@ defmodule Xairo.MatrixTest do
   alias Xairo.Matrix
   doctest Matrix
 
+  @epsilon 1.0e-8
+
   test "set matrix" do
     matrix = Matrix.new(xx: 2, yy: 3, xy: 0.8, yx: 1.8, xt: 20, yt: -20)
 
@@ -29,13 +31,92 @@ defmodule Xairo.MatrixTest do
 
     matrix = Xairo.get_matrix(image)
 
-    epsilon = 1.0e-8
+    assert_in_delta(matrix.xx, 2.59807621, @epsilon)
+    assert_in_delta(matrix.yy, 2.59807621, @epsilon)
+    assert_in_delta(matrix.xy, -1.5, @epsilon)
+    assert_in_delta(matrix.yx, 1.5, @epsilon)
+    assert_in_delta(matrix.xt, 60, @epsilon)
+    assert_in_delta(matrix.yt, 5.35898384, @epsilon)
+  end
 
-    assert_in_delta(matrix.xx, 2.59807621, epsilon)
-    assert_in_delta(matrix.yy, 2.59807621, epsilon)
-    assert_in_delta(matrix.xy, -1.5, epsilon)
-    assert_in_delta(matrix.yx, 1.5, epsilon)
-    assert_in_delta(matrix.xt, 60, epsilon)
-    assert_in_delta(matrix.yt, 5.35898384, epsilon)
+  test "identity/0" do
+    assert Matrix.identity() == Matrix.new()
+  end
+
+  describe "transformations" do
+    setup do
+      matrix = Matrix.new(xt: 10, yt: 10)
+      {:ok, matrix: matrix}
+    end
+
+    test "translate/3", %{matrix: matrix} do
+      assert Matrix.translate(matrix, 14, 17) == Matrix.new(xt: 24, yt: 27)
+    end
+
+    test "scale/3", %{matrix: matrix} do
+      assert Matrix.scale(matrix, 5, 3) == Matrix.new(xx: 5.0, yy: 3.0, xt: 10, yt: 10)
+    end
+
+    test "rotate/2", %{matrix: matrix} do
+      matrix = Matrix.rotate(matrix, :math.pi() / 4)
+
+      assert_in_delta(matrix.xx, 0.70710678, @epsilon)
+      assert_in_delta(matrix.yy, 0.70710678, @epsilon)
+      assert_in_delta(matrix.yx, 0.70710678, @epsilon)
+      assert_in_delta(matrix.xy, -0.70710678, @epsilon)
+    end
+
+    test "invert/1", %{matrix: matrix} do
+      assert Matrix.invert(matrix) == Matrix.new(xt: -10, yt: -10)
+    end
+
+    test "multiply/2", %{matrix: matrix} do
+      m1 = Matrix.rotate(matrix, :math.pi() / 4)
+
+      m2 = Matrix.identity() |> Matrix.scale(5, 3)
+
+      m3 = Matrix.multiply(m1, m2)
+      m4 = Matrix.multiply(m2, m1)
+
+      assert_in_delta(m3.xx, 3.5355339, @epsilon)
+      assert_in_delta(m3.yy, 2.12132034, @epsilon)
+      assert_in_delta(m3.xy, -3.5355339, @epsilon)
+      assert_in_delta(m3.yx, 2.12132034, @epsilon)
+      assert_in_delta(m3.xt, 50, @epsilon)
+      assert_in_delta(m3.yt, 30, @epsilon)
+
+      assert_in_delta(m4.xx, 3.5355339, @epsilon)
+      assert_in_delta(m4.yy, 2.12132034, @epsilon)
+      assert_in_delta(m4.xy, -2.12132034, @epsilon)
+      assert_in_delta(m4.yx, 3.5355339, @epsilon)
+      assert_in_delta(m4.xt, 10, @epsilon)
+      assert_in_delta(m4.yt, 10, @epsilon)
+    end
+  end
+
+  test "transform_point/2" do
+    matrix =
+      Matrix.identity()
+      |> Matrix.translate(10, 15)
+      |> Matrix.scale(5, 3)
+      |> Matrix.rotate(:math.pi() / 5)
+
+    p = Matrix.transform_point(matrix, Xairo.Point.new(10, 10))
+
+    assert_in_delta(p.x, 21.0615871, @epsilon)
+    assert_in_delta(p.y, 56.9040674, @epsilon)
+  end
+
+  test "transform_distance/2" do
+    matrix =
+      Matrix.identity()
+      |> Matrix.translate(10, 15)
+      |> Matrix.scale(5, 3)
+      |> Matrix.rotate(:math.pi() / 5)
+
+    v = Matrix.transform_distance(matrix, Xairo.Vector.new(10, 10))
+
+    assert_in_delta(v.x, 11.0615871, @epsilon)
+    assert_in_delta(v.y, 41.9040674, @epsilon)
   end
 end


### PR DESCRIPTION
Add transformation operations for `Xairo.Matrix`

* `identity/0`
* `translate/3`
* `scale/3`
* `rotate/2`
* `invert/1`
* `multiply/2`
* `transform_point/2`
* `transform_distance/2`

Refactor Matrix functions to use From trait

