### PR TITLE
Add `Extents.for/2` function

### DIFF
--- a/lib/xairo/text/extents.ex
+++ b/lib/xairo/text/extents.ex
@@ -42,6 +42,16 @@ defmodule Xairo.Text.Extents do
           y_advance: number()
         }
 
+  @doc """
+  Returns the text exetnts of the given text in the context of the
+  image's configuration.
+  """
+  def for(text, %Xairo.Image{resource: resource}) do
+    with {:ok, extents} <- Xairo.Native.text_extents(resource, text) do
+      extents
+    end
+  end
+
   defimpl Inspect do
     import Inspect.Algebra
 

--- a/test/xairo/text/extents_test.exs
+++ b/test/xairo/text/extents_test.exs
@@ -1,0 +1,15 @@
+defmodule Xairo.Text.ExtentsTest do
+  use ExUnit.Case, async: true
+
+  alias Xairo.Text.Extents
+
+  describe "for/2" do
+    test "returns a Text.Extents struct for the given string in the context of the image" do
+      image = Xairo.new_image(1000, 1000, 20)
+
+      %Extents{} = extents = Extents.for("hello", image)
+
+      assert extents.text == "hello"
+    end
+  end
+end


### PR DESCRIPTION
to return text extents for provided text in the context of a provided image
